### PR TITLE
Return media entries for playlists

### DIFF
--- a/harmonize/harmonize/db/models.py
+++ b/harmonize/harmonize/db/models.py
@@ -37,13 +37,25 @@ class MediaEntryPlaylistLink(SQLModel, table=True):
     media_entry_id: uuid.UUID = Field(foreign_key='mediaentry.id', primary_key=True)
 
 
-class Playlist(BaseSchema, SQLModel, table=True):
-    id: uuid.UUID = Field(default_factory=uuid.uuid4, primary_key=True)
+class PlaylistBase(SQLModel):
     name: str
     date_created: datetime.datetime = Field(default_factory=datetime.datetime.utcnow)
+
+
+class Playlist(BaseSchema, PlaylistBase, table=True):
+    id: uuid.UUID = Field(default_factory=uuid.uuid4, primary_key=True)
+
     media_entries: list['MediaEntry'] = Relationship(
         back_populates='playlists', link_model=MediaEntryPlaylistLink
     )
+
+
+class PlaylistPublic(PlaylistBase):
+    id: uuid.UUID
+
+
+class PlaylistWithMediaEntries(PlaylistBase):
+    media_entries: list['MediaEntry'] = []
 
 
 class MediaEntry(BaseSchema, SQLModel, table=True):

--- a/harmonize/harmonize/router/playlist.py
+++ b/harmonize/harmonize/router/playlist.py
@@ -4,7 +4,7 @@ from fastapi import APIRouter, Depends
 from sqlmodel import Session, select
 
 from harmonize.db.database import get_session
-from harmonize.db.models import MediaEntry, Playlist
+from harmonize.db.models import MediaEntry, Playlist, PlaylistWithMediaEntries
 from harmonize.defs.response import BaseResponse
 
 router = APIRouter(prefix='/api')
@@ -58,8 +58,9 @@ async def get_playlist(
 #     return BaseResponse[list[Playlist]](message='Found', status_code=201, value=playlists)
 
 
-@router.get('/playlist')
-async def get_playlists(session: Session = Depends(get_session)) -> BaseResponse[list[Playlist]]:
+@router.get('/playlist', response_model=list[PlaylistWithMediaEntries])
+async def get_playlists(session: Session = Depends(get_session)) -> list[Playlist]:
     statement = select(Playlist)
     playlists = list(session.exec(statement))
-    return BaseResponse[list[Playlist]](message='Found', status_code=201, value=playlists)
+
+    return playlists


### PR DESCRIPTION
Follow sqlmodel docs for handling returning relationship data
https://sqlmodel.tiangolo.com/tutorial/fastapi/relationships/#update-the-path-operations

We have to define a separate model to tell fastapi what properties we want to return, probably need to restructure the models a bit to do what the docs here show, but you then define a model with what fields you want in the response and it shows up, these commits get the media entries to return

![image](https://github.com/user-attachments/assets/56d6bf05-0bf9-44d4-a39a-26a6aa972a9c)
